### PR TITLE
Add raspberry pi 3 build

### DIFF
--- a/docker/rpi3/Dockerfile
+++ b/docker/rpi3/Dockerfile
@@ -1,0 +1,21 @@
+FROM balenalib/raspberrypi3-node:8
+
+USER root
+
+COPY --from=ctcoss/spark-server --chown=nobody:root /opt/app-root/src/ /opt/app-root
+COPY --from=ctcoss/spark-server --chown=nobody:root /usr/libexec/s2i /usr/libexec/s2i
+
+WORKDIR /opt/app-root/src
+
+USER nobody
+
+EXPOSE 5683
+EXPOSE 8080
+
+ENV NPM_RUN=start                                   \
+    DEV_MODE=false                                  \
+    HOME=/opt/app-root/src                          \
+    NPM_CONFIG_PREFIX=/opt/app-root/src/.npm-global \
+    PATH="$PATH:/opt/app-root/src/node_modules/.bin"
+
+CMD /usr/libexec/s2i/run


### PR DESCRIPTION
Using balena (formerly resin) image for base.  Copy artifacts from the master build :fearful: (for now).

No need to enable qemu in build, but if the need arises then here looks to be a great solution

https://github.com/docker/hub-feedback/issues/1261#issuecomment-441126749
